### PR TITLE
Allowing setting collection id for Roles and Users from web.config

### DIFF
--- a/src/identity.documentdb/Constants.cs
+++ b/src/identity.documentdb/Constants.cs
@@ -21,8 +21,12 @@ namespace ElCamino.AspNet.Identity.DocumentDB
 
         public static class DocumentCollectionIds
         {
-            public const string RolesCollection = "Roles";
-            public const string UsersCollection = "Users";
+            public static string RolesCollection = WebConfigurationManager.AppSettings["RolesCollection"];
+            public static string UsersCollection = WebConfigurationManager.AppSettings["UsersCollection"];
+            static DocumentCollectionIds() {
+                RolesCollection = string.IsNullOrWhiteSpace(RolesCollection) ? "Roles" : RolesCollection;
+                UsersCollection = string.IsNullOrWhiteSpace(UsersCollection) ? "Users" : UsersCollection;
+            }
         }
 
         public static class RowKeyConstants


### PR DESCRIPTION
Some implementations require custom name for users and roles collections. This change will allow to optionally specify collection ids from web.config